### PR TITLE
add flag '#copy_constructible_by_clone;' to define copy constructor with `.clone()`

### DIFF
--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -92,6 +92,7 @@ pub struct ZngurType {
     pub constructors: Vec<ZngurConstructor>,
     pub cpp_value: Option<(String, String)>,
     pub cpp_ref: Option<String>,
+    pub copy_construct_by_clone: bool,
 }
 
 pub struct ZngurTrait {

--- a/zngur-def/src/lib.rs
+++ b/zngur-def/src/lib.rs
@@ -92,7 +92,7 @@ pub struct ZngurType {
     pub constructors: Vec<ZngurConstructor>,
     pub cpp_value: Option<(String, String)>,
     pub cpp_ref: Option<String>,
-    pub copy_construct_by_clone: bool,
+    pub is_copy_constructible_by_clone: bool,
 }
 
 pub struct ZngurTrait {

--- a/zngur-generator/src/cpp.rs
+++ b/zngur-generator/src/cpp.rs
@@ -482,7 +482,7 @@ pub struct CppTypeDefinition {
     pub wellknown_traits: Vec<ZngurWellknownTraitData>,
     pub cpp_value: Option<(String, String)>,
     pub cpp_ref: Option<String>,
-    pub is_copy_construct_from_clone: bool,
+    pub is_copy_constructible_by_clone: bool,
 }
 
 impl CppTypeDefinition {
@@ -689,7 +689,7 @@ inline size_t __zngur_internal_size_of< {ref_kind} < {ty} > >() {{
         let is_copy = self
             .wellknown_traits
             .contains(&ZngurWellknownTraitData::Copy);
-        let is_copy_construct_from_clone = self.is_copy_construct_from_clone;
+        let is_copy_constructible_by_clone = self.is_copy_constructible_by_clone;
         writeln!(
             state,
             r#"
@@ -838,7 +838,7 @@ private:
     "#,
                             ty = self.ty.path.name(),
                         )?;
-                    } else if is_copy_construct_from_clone {
+                    } else if is_copy_constructible_by_clone {
                         let drop_in_place = self
                             .wellknown_traits
                             .iter()

--- a/zngur-generator/src/cpp.rs
+++ b/zngur-generator/src/cpp.rs
@@ -482,6 +482,7 @@ pub struct CppTypeDefinition {
     pub wellknown_traits: Vec<ZngurWellknownTraitData>,
     pub cpp_value: Option<(String, String)>,
     pub cpp_ref: Option<String>,
+    pub is_copy_construct_from_clone: bool,
 }
 
 impl CppTypeDefinition {
@@ -688,6 +689,7 @@ inline size_t __zngur_internal_size_of< {ref_kind} < {ty} > >() {{
         let is_copy = self
             .wellknown_traits
             .contains(&ZngurWellknownTraitData::Copy);
+        let is_copy_construct_from_clone = self.is_copy_construct_from_clone;
         writeln!(
             state,
             r#"
@@ -831,6 +833,54 @@ private:
     }}
     {ty}& operator=({ty}&& other) {{
         {copy_data}
+        return *this;
+    }}
+    "#,
+                            ty = self.ty.path.name(),
+                        )?;
+                    } else if is_copy_construct_from_clone {
+                        let drop_in_place = self
+                            .wellknown_traits
+                            .iter()
+                            .find_map(|x| match x {
+                                ZngurWellknownTraitData::Drop { drop_in_place } => {
+                                    Some(drop_in_place)
+                                }
+                                _ => None,
+                            })
+                            .unwrap();
+                        writeln!(
+                            state,
+                            r#"
+    {ty}() : drop_flag(false) {{ {alloc_heap} }}
+    ~{ty}() {{
+        if (drop_flag) {{
+            {drop_in_place}(&data[0]);
+        }}
+        {free_heap}
+    }}
+    {ty}& operator=(const {ty}& other) {{
+        if (this != &other)
+        {{
+        return *this = other.clone();
+        }}
+        return *this;
+        }}
+    {ty}(const {ty}& other) : {ty}(other.clone()) {{ }}
+    {ty}({ty}&& other) : drop_flag(false) {{
+        {alloc_heap}
+        *this = ::std::move(other);
+    }}
+    {ty}& operator=({ty}&& other) {{
+        if (this != &other)
+        {{
+            if (drop_flag) {{
+                {drop_in_place}(&data[0]);
+            }}
+            this->drop_flag = other.drop_flag;
+            {copy_data}
+            other.drop_flag = false;
+        }}
         return *this;
     }}
     "#,

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -43,7 +43,7 @@ impl ZngurGenerator {
             constructors: vec![],
             cpp_value: None,
             cpp_ref: None,
-            copy_construct_by_clone: false,
+            is_copy_constructible_by_clone: false,
         });
         let mut cpp_file = CppFile::default();
         cpp_file.additional_includes = zng.additional_includes;
@@ -210,7 +210,7 @@ impl ZngurGenerator {
                 } else {
                     None
                 },
-                is_copy_construct_from_clone: ty_def.copy_construct_by_clone,
+                is_copy_constructible_by_clone: ty_def.is_copy_constructible_by_clone,
             });
         }
         for func in zng.funcs {
@@ -444,8 +444,8 @@ fn augment_type_with_impls(
         if !matches_generic(&ty.ty, &zng_impl.ty, &mut mapping) {
             continue;
         }
-        if zng_impl.copy_construct_by_clone {
-            ty.copy_construct_by_clone = true
+        if zng_impl.is_copy_constructible_by_clone {
+            ty.is_copy_constructible_by_clone = true
         }
         // For these we just choose the first match layout. Worst case is a compile error
         ty.layout = ty.layout.or(zng_impl.layout);

--- a/zngur-generator/src/lib.rs
+++ b/zngur-generator/src/lib.rs
@@ -43,6 +43,7 @@ impl ZngurGenerator {
             constructors: vec![],
             cpp_value: None,
             cpp_ref: None,
+            copy_construct_by_clone: false,
         });
         let mut cpp_file = CppFile::default();
         cpp_file.additional_includes = zng.additional_includes;
@@ -209,6 +210,7 @@ impl ZngurGenerator {
                 } else {
                     None
                 },
+                is_copy_construct_from_clone: ty_def.copy_construct_by_clone,
             });
         }
         for func in zng.funcs {
@@ -442,7 +444,9 @@ fn augment_type_with_impls(
         if !matches_generic(&ty.ty, &zng_impl.ty, &mut mapping) {
             continue;
         }
-
+        if zng_impl.copy_construct_by_clone {
+            ty.copy_construct_by_clone = true
+        }
         // For these we just choose the first match layout. Worst case is a compile error
         ty.layout = ty.layout.or(zng_impl.layout);
         if ty.cpp_ref.is_none() {

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -120,6 +120,7 @@ enum ParsedLayoutPolicy<'a> {
 enum ParsedTypeItem<'a> {
     Layout(Span, ParsedLayoutPolicy<'a>),
     Traits(Vec<Spanned<ZngurWellknownTrait>>),
+    CopyConstructByClone,
     Constructor {
         name: Option<&'a str>,
         args: ParsedConstructorArgs<'a>,
@@ -195,6 +196,7 @@ impl ParsedItem<'_> {
                 let mut layout_span = None;
                 let mut cpp_value = None;
                 let mut cpp_ref = None;
+                let mut copy_construct_by_clone = false;
                 for item in items {
                     let item_span = item.span;
                     let item = item.inner;
@@ -239,6 +241,9 @@ impl ParsedItem<'_> {
                         }
                         ParsedTypeItem::Traits(tr) => {
                             wellknown_traits.extend(tr);
+                        }
+                        ParsedTypeItem::CopyConstructByClone => {
+                            copy_construct_by_clone = true;
                         }
                         ParsedTypeItem::Constructor { name, args } => {
                             constructors.push(ZngurConstructor {
@@ -329,6 +334,7 @@ impl ParsedItem<'_> {
                     constructors,
                     cpp_value,
                     cpp_ref,
+                    copy_construct_by_clone,
                 };
                 if vars.is_some() {
                     r.impls.push(type_or_impl);
@@ -1048,9 +1054,15 @@ fn type_or_impl_item<'a>()
                 Token::Str(c) => c,
             })
             .map(|x| ParsedTypeItem::CppRef { cpp_type: x });
+
+        let copy_constructor_by_clone =
+            just([Token::Sharp, Token::Ident("copy_construct_by_clone")])
+                .to(ParsedTypeItem::CopyConstructByClone);
+
         choice((
             layout,
             traits,
+            copy_constructor_by_clone,
             constructor,
             cpp_value,
             cpp_ref,

--- a/zngur-parser/src/lib.rs
+++ b/zngur-parser/src/lib.rs
@@ -120,7 +120,7 @@ enum ParsedLayoutPolicy<'a> {
 enum ParsedTypeItem<'a> {
     Layout(Span, ParsedLayoutPolicy<'a>),
     Traits(Vec<Spanned<ZngurWellknownTrait>>),
-    CopyConstructByClone,
+    IsCopyConstructibleByClone,
     Constructor {
         name: Option<&'a str>,
         args: ParsedConstructorArgs<'a>,
@@ -196,7 +196,7 @@ impl ParsedItem<'_> {
                 let mut layout_span = None;
                 let mut cpp_value = None;
                 let mut cpp_ref = None;
-                let mut copy_construct_by_clone = false;
+                let mut is_copy_constructible_by_clone = false;
                 for item in items {
                     let item_span = item.span;
                     let item = item.inner;
@@ -242,8 +242,8 @@ impl ParsedItem<'_> {
                         ParsedTypeItem::Traits(tr) => {
                             wellknown_traits.extend(tr);
                         }
-                        ParsedTypeItem::CopyConstructByClone => {
-                            copy_construct_by_clone = true;
+                        ParsedTypeItem::IsCopyConstructibleByClone => {
+                            is_copy_constructible_by_clone = true;
                         }
                         ParsedTypeItem::Constructor { name, args } => {
                             constructors.push(ZngurConstructor {
@@ -334,7 +334,7 @@ impl ParsedItem<'_> {
                     constructors,
                     cpp_value,
                     cpp_ref,
-                    copy_construct_by_clone,
+                    is_copy_constructible_by_clone,
                 };
                 if vars.is_some() {
                     r.impls.push(type_or_impl);
@@ -1055,14 +1055,14 @@ fn type_or_impl_item<'a>()
             })
             .map(|x| ParsedTypeItem::CppRef { cpp_type: x });
 
-        let copy_constructor_by_clone =
-            just([Token::Sharp, Token::Ident("copy_construct_by_clone")])
-                .to(ParsedTypeItem::CopyConstructByClone);
+        let is_copy_constructible_by_clone =
+            just([Token::Sharp, Token::Ident("copy_constructible_by_clone")])
+                .to(ParsedTypeItem::IsCopyConstructibleByClone);
 
         choice((
             layout,
             traits,
-            copy_constructor_by_clone,
+            is_copy_constructible_by_clone,
             constructor,
             cpp_value,
             cpp_ref,


### PR DESCRIPTION
Adds support for the specifier `#[copy_constructible_by_clone]`, which means that the Rust type is not `Copy`, but the C++ type will have a generated copy constructor and copy-assignment operator that works by calling `.clone()` on the RHS.

Most types should not implement this, but it is useful for pointer types like `Arc<T>`.